### PR TITLE
Remove --gh flag alias and update GitHub URLs to hyunhwan-bcm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Be respectful, inclusive, and professional in all interactions. We're all here t
 
 If you find a bug:
 
-1. Check if it's already reported in [Issues](https://github.com/yourusername/prettipy/issues)
+1. Check if it's already reported in [Issues](https://github.com/hyunhwan-bcm/prettipy/issues)
 2. If not, create a new issue with:
    - Clear title and description
    - Steps to reproduce

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -25,8 +25,8 @@ authors = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yourusername/prettipy"      # Change this
-Repository = "https://github.com/yourusername/prettipy.git" # Change this
+Homepage = "https://github.com/hyunhwan-bcm/prettipy"      # Change this
+Repository = "https://github.com/hyunhwan-bcm/prettipy.git" # Change this
 ```
 
 **`src/prettipy/__init__.py`**:
@@ -90,7 +90,7 @@ pytest --cov=prettipy
    git init
    git add .
    git commit -m "Initial commit"
-   git remote add origin https://github.com/yourusername/prettipy.git
+   git remote add origin https://github.com/hyunhwan-bcm/prettipy.git
    git push -u origin main
    ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ prettipy -w 100
 prettipy --no-linking
 
 # Clone and convert a GitHub repository
-prettipy --gh https://github.com/user/repo
+prettipy --github https://github.com/user/repo
 
 # Clone a specific branch
 prettipy --github https://github.com/user/repo --branch develop
@@ -72,13 +72,13 @@ Prettipy can clone GitHub repositories and convert them to PDF with a single com
 
 ```bash
 # Clone and convert from default branch
-prettipy --gh https://github.com/user/repo
+prettipy --github https://github.com/user/repo
 
 # Clone from specific branch
-prettipy --gh https://github.com/user/repo --branch develop
+prettipy --github https://github.com/user/repo --branch develop
 
 # Combine with other options
-prettipy --gh https://github.com/user/repo -o project.pdf --sort dependency
+prettipy --github https://github.com/user/repo -o project.pdf --sort dependency
 ```
 
 ### Features
@@ -92,13 +92,13 @@ prettipy --gh https://github.com/user/repo -o project.pdf --sort dependency
 
 ```bash
 # Convert the popular requests library
-prettipy --gh https://github.com/psf/requests -o requests_source.pdf
+prettipy --github https://github.com/psf/requests -o requests_source.pdf
 
 # Convert a specific branch of Django
 prettipy --github https://github.com/django/django -b stable/4.2.x -o django_4.2.pdf
 
 # Convert with custom settings
-prettipy --gh https://github.com/user/repo \
+prettipy --github https://github.com/user/repo \
   --branch main \
   -o output.pdf \
   --page-size a4 \
@@ -218,7 +218,7 @@ optional arguments:
   --no-linking          Disable auto-linking to function/variable definitions
   --sort {dependency,lexicographic,none}
                         File sorting method (default: lexicographic)
-  --github, --gh URL    Clone and convert a GitHub repository
+  --github URL          Clone and convert a GitHub repository
   --branch, -b BRANCH   Branch to checkout when cloning (default: repo's default branch)
   -v, --verbose         Enable verbose output
   --version             Show program's version number and exit
@@ -239,10 +239,10 @@ This will create `output.pdf` with all Python files from the current directory.
 
 ```bash
 # Clone and convert from default branch
-prettipy --gh https://github.com/psf/requests
+prettipy --github https://github.com/psf/requests
 
 # Clone from specific branch
-prettipy --gh https://github.com/user/repo --branch develop -o output.pdf
+prettipy --github https://github.com/user/repo --branch develop -o output.pdf
 ```
 
 #### Convert With Custom Settings
@@ -385,7 +385,7 @@ More themes coming soon!
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/prettipy.git
+git clone https://github.com/hyunhwan-bcm/prettipy.git
 cd prettipy
 
 # Create virtual environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prettipy"
-version = "0.1.4"
+version = "0.1.5"
 description = "Convert Python code to beautifully formatted, syntax-highlighted PDFs"
 readme = "README.md"
 authors = [
@@ -49,10 +49,10 @@ rich = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yourusername/prettipy"
-Documentation = "https://github.com/yourusername/prettipy#readme"
-Repository = "https://github.com/yourusername/prettipy.git"
-"Bug Tracker" = "https://github.com/yourusername/prettipy/issues"
+Homepage = "https://github.com/hyunhwan-bcm/prettipy"
+Documentation = "https://github.com/hyunhwan-bcm/prettipy#readme"
+Repository = "https://github.com/hyunhwan-bcm/prettipy.git"
+"Bug Tracker" = "https://github.com/hyunhwan-bcm/prettipy/issues"
 
 [project.scripts]
 prettipy = "prettipy.cli:main"

--- a/src/prettipy/cli.py
+++ b/src/prettipy/cli.py
@@ -57,10 +57,10 @@ Examples:
   prettipy --sort dependency           # Sort files by dependencies
   prettipy --sort lexicographic        # Sort files alphabetically
   prettipy --sort none                 # No sorting (discovery order)
-  prettipy --gh https://github.com/user/repo  # Clone and convert GitHub repo
+  prettipy --github https://github.com/user/repo  # Clone and convert GitHub repo
   prettipy --github https://github.com/user/repo -b dev  # Clone specific branch
 
-For more information, visit: https://github.com/yourusername/prettipy
+For more information, visit: https://github.com/hyunhwan-bcm/prettipy
             """,
         )
 
@@ -148,7 +148,6 @@ For more information, visit: https://github.com/yourusername/prettipy
 
         parser.add_argument(
             "--github",
-            "--gh",
             dest="github_url",
             help="Clone and convert a GitHub repository (e.g., https://github.com/user/repo)",
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ class TestCLIArgumentValidation:
 
         # Test that using both --github and --files returns error code
         result = cli.run(
-            ["--gh", "https://github.com/user/repo", "--files", "test.py", "-o", "test.pdf"]
+            ["--github", "https://github.com/user/repo", "--files", "test.py", "-o", "test.pdf"]
         )
 
         assert result == 1, "Should return error code when --github and --files are both used"


### PR DESCRIPTION
This PR makes the following changes:

- **Remove --gh flag alias**: Only --github flag is now supported for cloning GitHub repositories
- **Update GitHub URLs**: Changed all references from yourusername/prettipy to hyunhwan-bcm/prettipy
- **Version bump**: Updated version from 0.1.4 to 0.1.5

## Files Updated:
- pyproject.toml - version bump and URL updates
- src/prettipy/cli.py - removed --gh alias, updated URLs
- README.md - updated all --gh examples to --github, updated GitHub URLs
- CONTRIBUTING.md - updated GitHub URLs
- QUICKSTART.md - updated GitHub URLs  
- tests/test_cli.py - updated test to use --github

## Testing:
All 76 tests pass successfully ✅